### PR TITLE
Replace duplicate lo_spellcheckdict by lao_words

### DIFF
--- a/laonlp/corpus/lao_words.py
+++ b/laonlp/corpus/lao_words.py
@@ -14,4 +14,4 @@ def lo_spellcheckdict()->list:
         return [i.strip() for i in f.readlines() if i[0]!="#"]
 
 def lao_words()->list:
-    return list(set(lo_spellcheckdict()+lo_spellcheckdict()))
+    return list(set(lao_dictionary()+lo_spellcheckdict()+lo_spellcheckdict()))

--- a/laonlp/corpus/lao_words.py
+++ b/laonlp/corpus/lao_words.py
@@ -14,4 +14,4 @@ def lo_spellcheckdict()->list:
         return [i.strip() for i in f.readlines() if i[0]!="#"]
 
 def lao_words()->list:
-    return list(set(lao_dictionary()+lo_spellcheckdict()+lo_spellcheckdict()))
+    return list(set(lao_dictionary()+lo_spellcheckdict()))


### PR DESCRIPTION
I suppose the function in `lao_words` is written to include results from both`lao_dictionary` and `lo_spellcheckdict`.

Currently, `lao_words` only returns results from `lo_spellcheckdict`. Was that a mistake?