### PR TITLE
LaoNLP v0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ Lao language Natural Language Processing (NLP)
 
 - Word tokenizer
 - Sentence tokenizer
-- Part-of-speech (new)
+- Part-of-speech
 - Lao to Thai script
 - Thai to Lao script
 - Word dictionary
+- Word Vector (**New**)
 
 ## Install
 ```
@@ -47,7 +48,7 @@ or BibTeX entry:
 ## License
 
 ```
-   Copyright 2020 Wannaphong Phatthiyaphaibun
+   Copyright 2020 - 2022 Wannaphong Phatthiyaphaibun
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-numpy
 pythainlp>=3.0.0
 huggingface_hub
 gensim

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,12 @@ from setuptools import find_packages, setup
 with open("README.md","r",encoding="utf-8-sig") as f:
     readme = f.read()
 
-requirements = [
-    "pythainlp>=2.1.0"
-]
+with open("requirements.txt","r",encoding="utf-8-sig") as f:
+    requirements = [i.strip() for i in f.readlines()]
+
 setup(
     name="LaoNLP",
-    version="0.6",
+    version="0.7",
     description="Lao Natural Language Processing library",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
- Add Lao word2vec https://github.com/wannaphong/LaoNLP/pull/6

**Install**: `pip install laonlp`

## Citations

If you use `LaoNLP` in your project or publication, please cite the library as follows

```
Wannaphong Phatthiyaphaibun. (2022). LaoNLP: Lao language Natural Language Processing. Zenodo. https://doi.org/10.5281/zenodo.6833407
```

Docs: https://github.com/wannaphong/LaoNLP/wiki