### PR TITLE
Make dependencies of less commonly used functionalities optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,24 @@ Lao language Natural Language Processing (NLP)
 pip install laonlp
 ```
 
+### Installation Options
+
+Some functionalities, like word vectors, may require extra packages. To install those requirements, specify a set of `[name]` immediately after `laonlp`:
+
+```
+pip install laonlp[extra1,extra2,...]
+```
+
+<details>
+  <summary>List of possible <code>extras</code></summary>
+
+- `full` (install everything)
+- `anyascii` (for support of the `anyascii` engine of Lao transliteration functionalities)
+- `word_vector` (for support of word vector functionalities)
+</details>
+
+For dependency details, look at `extras` variable in [`setup.py`](https://github.com/wannaphong/LaoNLP/blob/master/setup.py).
+
 Documentation: https://github.com/wannaphong/LaoNLP/wiki
 
 ## Citations

--- a/laonlp/transliterate/__init__.py
+++ b/laonlp/transliterate/__init__.py
@@ -21,7 +21,10 @@ __all__ = [
     "thai2lao_transliteration",
 	"transliterate"
 ]
-from anyascii import anyascii
+try:
+    from anyascii import anyascii
+except ModuleNotFoundError:
+    raise ModuleNotFoundError('The anyascii engine of Lao transliteration functionalities require AnyAscii which is not currently installed. Please try installing the package via "pip install anyascii".')
 
 # Naive Lao script to Thai script transliteration.
 # Data from https://github.com/google/language-resources/blob/master/lo/Laoo-Thai.txt

--- a/laonlp/word_vector/word2vec.py
+++ b/laonlp/word_vector/word2vec.py
@@ -15,9 +15,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from typing import List
-import gensim
-from huggingface_hub import hf_hub_download
 
+try:
+    import gensim
+except ModuleNotFoundError:
+    raise ModuleNotFoundError('Word vector functionalities require gensim which is not currently installed. Please try installing the package via "pip install gensim".')
+try:
+    from huggingface_hub import hf_hub_download
+except ModuleNotFoundError:
+    raise ModuleNotFoundError('Word vector functionalities require huggingface_hub which is not currently installed. Please try installing the package via "pip install huggingface_hub".')
 
 class Word2Vec:
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,1 @@
 pythainlp>=3.0.0
-huggingface_hub
-gensim
-anyascii>=0.3.2

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,16 @@ with open("README.md","r",encoding="utf-8-sig") as f:
 with open("requirements.txt","r",encoding="utf-8-sig") as f:
     requirements = [i.strip() for i in f.readlines()]
 
+extras = {
+    "anyascii": ["anyascii>=0.3.2"],
+    "word_vector": ["gensim", "huggingface-hub"],
+    "full": [
+        "anyascii>=0.3.2",
+        "gensim",
+        "huggingface-hub"
+    ]
+}
+
 setup(
     name="LaoNLP",
     version="1.1",
@@ -40,6 +50,7 @@ setup(
         ]
     },
     install_requires=requirements,
+    extras_require=extras,
     license="Apache Software License 2.0",
     zip_safe=False,
     keywords=[


### PR DESCRIPTION
While functions like tokenization and POS tagging are commonly used by `LaoNLP` users, other functionalities are less commonly used but have heavier dependencies, so this PR makes them optional.

The [Installation Options](https://github.com/PyThaiNLP/pythainlp#installation-options) part of README is added accordingly to mimic that of [PyThaiNLP](https://github.com/PyThaiNLP/pythainlp#installation-options), so when more and more functionalities are added to `LaoNLP` in future releases, the extra dependencies could be conveniently added here.