### PR TITLE
Preserve terminal punctuation marks during sentence tokenization

### DIFF
--- a/laonlp/tokenize/__init__.py
+++ b/laonlp/tokenize/__init__.py
@@ -14,6 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import re
 from typing import List
 from pythainlp.tokenize import Tokenizer
 from laonlp.corpus import lao_words
@@ -42,4 +43,7 @@ def sent_tokenize(txt: str) -> List[str]:
     :return: returns a list of lao sentence
     :rtype: list
     """
-    return txt.split(".")
+    sentences = []
+    for part in re.split(r"(?<=\.)(?!(?:\.|$))", txt):
+        sentences.append(part.strip())
+    return sentences

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -9,4 +9,7 @@ class TestTokenizePackage(unittest.TestCase):
         self.assertIsNotNone(word_tokenize("ພາສາລາວໃນປັດຈຸບັນ."))
 
     def test_sent_tokenize(self):
-        self.assertIsNotNone(sent_tokenize("ພາສາລາວໃນປັດຈຸບັນ.ນະຄອນຫຼວງວຽງຈັນ"))
+        self.assertEqual(
+            sent_tokenize("ພາສາລາວໃນປັດຈຸບັນ.ນະຄອນຫຼວງວຽງຈັນ"),
+            ["ພາສາລາວໃນປັດຈຸບັນ.", "ນະຄອນຫຼວງວຽງຈັນ"]
+        )


### PR DESCRIPTION
The current implementation of `sent_tokenize` uses `str.split` which would not preserve the separator (the ending periods) at the end of each sentence. This PR uses `re.split` instead to preserve the terminal punctuation marks during sentence tokenization.