### PR TITLE
Exclude test suite from the package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     author="Wannaphong",
     author_email="wannaphong@yahoo.com",
     url="https://github.com/wannaphong/laonlp",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests"]),
     test_suite="tests",
     python_requires=">=3.6",
     package_data={


### PR DESCRIPTION
The test suite should be excluded from the package and the prebuilt wheel, as they are only for development use.