### PR TITLE
Make return values of laonlp.translate.word_dictionary consistent with type hint

### DIFF
--- a/laonlp/translate/mopt_dict.py
+++ b/laonlp/translate/mopt_dict.py
@@ -21,12 +21,12 @@ def dictionary(word: str, src: str, target: str) -> list:
     if src == "lao" and target == "eng":
         _temp = mopt_dict.get_lao_eng()
         if word not in list(_temp.keys()):
-            return None
+            return []
         return _temp[word]
     elif src == "eng" and target == "lao":
         _temp = mopt_dict.get_eng_lao()
         if word not in list(_temp.keys()):
-            return None
+            return []
         return _temp[word]
     else:
-        return word
+        return [word]

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -6,4 +6,8 @@ from laonlp.translate import word_dictionary
 
 class TestTagPackage(unittest.TestCase):
     def test_word_dictionary(self):
-        self.assertIsNotNone(word_dictionary("cat", "en", "lao"))
+        self.assertNotEqual(word_dictionary("cat", "eng", "lao"), ["cat"])
+        self.assertNotEqual(word_dictionary("ມັດ້າຣະ", "lao", "eng"), ["ມັດ້າຣະ"])
+        self.assertEqual(word_dictionary("nonexistent_word", "eng", "lao"), [])
+        self.assertEqual(word_dictionary("nonexistent_word", "lao", "eng"), [])
+        self.assertEqual(word_dictionary("nonexistent_word", "test", "test"), ["nonexistent_word"])


### PR DESCRIPTION
This PR makes the return values of `laonlp.translate.word_dictionary` consistent with the type hint, and update the tests to test them more thoroughly.